### PR TITLE
feat: 회원가입 시 실제 서버에 데이터 전송

### DIFF
--- a/front/pages/signup.js
+++ b/front/pages/signup.js
@@ -1,6 +1,7 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Head from 'next/head';
+import Router from 'next/router';
 import { Form, Input, Checkbox, Button } from 'antd';
 import styled from 'styled-components';
 
@@ -14,7 +15,9 @@ const ErrorMessage = styled.div`
 
 const Signup = () => {
   const dispatch = useDispatch();
-  const { signUpLoading } = useSelector((state) => state.user);
+  const { signUpLoading, signUpDone, signUpError } = useSelector(
+    (state) => state.user
+  );
   const [email, onChangeEmail] = useInput('');
   const [nickname, onChangeNickname] = useInput('');
   const [password, onChangePassword] = useInput('');
@@ -29,12 +32,25 @@ const Signup = () => {
     [password]
   );
 
-  const [term, setTerm] = useState('');
+  const [term, setTerm] = useState(false);
   const [termError, setTermError] = useState(false);
   const onChangeTerm = useCallback((e) => {
     setTerm(e.target.checked);
     setTermError(false);
   }, []);
+
+  useEffect(() => {
+    if (signUpDone) {
+      Router.replace('/');
+      dispatch({ type: SIGN_UP.clear });
+    }
+  }, [signUpDone]);
+
+  useEffect(() => {
+    if (signUpError) {
+      alert(signUpError);
+    }
+  }, [signUpError]);
 
   const onSubmitForm = useCallback(() => {
     if (password !== passwordCheck) {
@@ -47,7 +63,7 @@ const Signup = () => {
       type: SIGN_UP.request,
       data: { email, password, nickname },
     });
-  }, [password, passwordCheck, term]);
+  }, [email, password, nickname, passwordCheck, term]);
 
   return (
     <AppLayout>

--- a/front/reducers/user.js
+++ b/front/reducers/user.js
@@ -132,6 +132,11 @@ const reducer = (state = initialState, action) =>
         draft.signUpLoading = false;
         draft.signUpError = action.error;
         break;
+      case SIGN_UP.clear:
+        draft.signUpLoading = false;
+        draft.signUpDone = false;
+        draft.signUpError = null;
+        break;
       case CHANGE_NICKNAME.request:
         draft.changeNicknameLoading = true;
         draft.changeNicknameDone = false;

--- a/front/sagas/user.js
+++ b/front/sagas/user.js
@@ -1,16 +1,15 @@
-import { all, fork, takeLatest, put, delay } from 'redux-saga/effects';
+import { all, fork, takeLatest, put, delay, call } from 'redux-saga/effects';
 import axios from 'axios';
 
 import { LOG_IN, LOG_OUT, SIGN_UP, FOLLOW, UNFOLLOW } from '../actions/user';
 
 function logInAPI(data) {
-  return axios.post('/api/login', data);
+  return axios.post('http://localhost:3065/user', data);
 }
 
 function* logIn(action) {
   try {
-    // const result = yield call(logInAPI, action.data);
-    yield delay(1000);
+    const result = yield call(logInAPI, action.data);
     yield put({
       type: LOG_IN.success,
       data: action.data,
@@ -24,13 +23,12 @@ function* logIn(action) {
 }
 
 function logOutAPI() {
-  return axios.post('/api/logout');
+  return axios.post('http://localhost:3065/logout');
 }
 
 function* logOut(action) {
   try {
-    // const result = yield call(logOutAPI);
-    yield delay(1000);
+    const result = yield call(logOutAPI);
     yield put({
       type: LOG_OUT.success,
       data: action.data,
@@ -43,14 +41,14 @@ function* logOut(action) {
   }
 }
 
-function signUpAPI() {
-  return axios.post('/api/signup');
+function signUpAPI(data) {
+  return axios.post('http://localhost:3065/user', data);
 }
 
 function* signUp(action) {
   try {
-    // const result = yield call(logOutAPI);
-    yield delay(1000);
+    const result = yield call(signUpAPI, action.data);
+    console.log(result);
     yield put({
       type: SIGN_UP.success,
       data: action.data,

--- a/front/utils/factory.js
+++ b/front/utils/factory.js
@@ -2,4 +2,5 @@ export const createAsyncActions = (suffixOfActions) => ({
   request: suffixOfActions + '_REQUEST',
   success: suffixOfActions + '_SUCCESS',
   failure: suffixOfActions + '_FAILURE',
+  clear: suffixOfActions + '_CLEAR',
 });


### PR DESCRIPTION
1. pages/signup.js
  - 회원 가입 완료 후 메인페이지로 리다이렉트 및 SIGN_UP_CLEAR 액션 수행
  - 중복된 이메일로 회원 가입 시 경고창 생성
  - fix: 회원가입 버튼을 여러 번 누를 경우 첫 번째 데이터로 고정되어있는 현상 수정

2. reducers/user.js
  - 회원가입 완료 후 다시 회원가입을 접근할 때 정상적으로 접근되지 않는 현상 수정을 위해 SIGN_UP_CLEAR 액션 생성

3. sagas/user.js
  - 회원가입 시 실제 서버로 데이터 전송

4. utils/factory.js
  - action을 만들 때 clear액션을 만들도록 추가