### PR TITLE
feat: 게시글 작성 및 댓글 작성 구현

### DIFF
--- a/back/app.js
+++ b/back/app.js
@@ -4,10 +4,12 @@ import session from 'express-session';
 import passport from 'passport';
 import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
+import morgan from 'morgan';
 
 import { sequelize } from './models/index.js';
 import userRouter from './router/user.js';
 import postRouter from './router/post.js';
+import postsRouter from './router/posts.js';
 import passportConfig from './passport/index.js';
 
 dotenv.config();
@@ -24,9 +26,11 @@ sequelize
   });
 passportConfig();
 
+app.use(morgan('dev'));
 app.use(
   cors({
-    origin: '*',
+    origin: 'http://localhost:3000',
+    credentials: true,
   })
 );
 app.use(cookieParser(process.env.COOKIE_SECRET));
@@ -44,10 +48,7 @@ app.use(passport.session());
 
 app.use('/user', userRouter);
 app.use('/post', postRouter);
-
-app.get('/', (req, res) => {
-  res.send();
-});
+app.use('/posts', postsRouter);
 
 app.listen(app.get('port'), () => {
   console.log('listening');

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
+        "morgan": "^1.10.0",
         "mysql2": "^2.3.3",
         "passport": "^0.6.0",
         "passport-local": "^1.0.0",
@@ -199,6 +200,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/bcrypt": {
       "version": "5.1.0",
@@ -1331,6 +1348,32 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/ms": {
@@ -2573,6 +2616,21 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "bcrypt": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.0.tgz",
@@ -3454,6 +3512,28 @@
       "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
       "requires": {
         "moment": ">= 2.9.0"
+      }
+    },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        }
       }
     },
     "ms": {

--- a/back/package.json
+++ b/back/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
+    "morgan": "^1.10.0",
     "mysql2": "^2.3.3",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",

--- a/back/router/post.js
+++ b/back/router/post.js
@@ -1,5 +1,67 @@
 import express from 'express';
 
+import { Post, Comment, Image, User } from '../models/index.js';
+import { isLoggedIn } from './middlewares.js';
+
 const router = express.Router();
+
+router.post('/', isLoggedIn, async (req, res, next) => {
+  try {
+    const post = await Post.create({
+      UserId: req.user.id,
+      content: req.body.content,
+    });
+    const fullPost = await Post.findOne({
+      where: {
+        id: post.id,
+      },
+      include: [
+        {
+          model: Image,
+        },
+        {
+          model: Comment,
+        },
+        {
+          model: User,
+          attributes: ['id', 'nickname'],
+        },
+      ],
+    });
+    res.status(201).json(fullPost);
+  } catch (error) {
+    console.error(error);
+    next(error);
+  }
+});
+
+router.post('/:postId/comment', isLoggedIn, async (req, res, next) => {
+  try {
+    const post = await Post.findOne({
+      where: {
+        id: req.params.postId,
+      },
+    });
+    if (!post) return res.status(403).send('Non-existent post');
+    const comment = await Comment.create({
+      UserId: req.user.id,
+      content: req.body.content,
+      PostId: req.params.postId,
+    });
+    const fullComment = await Comment.findOne({
+      where: { id: comment.id },
+      include: [
+        {
+          model: User,
+          attributes: ['id', 'nickname'],
+        },
+      ],
+    });
+    return res.json(fullComment);
+  } catch (error) {
+    console.error(error);
+    return next(error);
+  }
+});
 
 export default router;

--- a/back/router/posts.js
+++ b/back/router/posts.js
@@ -1,0 +1,39 @@
+import express from 'express';
+
+import { Post, User, Comment, Image } from '../models/index.js';
+
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const posts = await Post.findAll({
+      limit: 10,
+      order: [
+        ['createdAt', 'DESC'],
+        [Comment, 'createdAt', 'DESC'],
+      ],
+      include: [
+        {
+          model: User,
+          attributes: ['id', 'nickname'],
+        },
+        {
+          model: Image,
+        },
+        {
+          model: Comment,
+          include: {
+            model: User,
+            attributes: ['id', 'nickname'],
+          },
+        },
+      ],
+    });
+    res.json(posts);
+  } catch (error) {
+    console.error(error);
+    next(error);
+  }
+});
+
+export default router;

--- a/back/router/user.js
+++ b/back/router/user.js
@@ -7,6 +7,46 @@ import { isLoggedIn, isNotLoggedIn } from './middlewares.js';
 
 const router = express.Router();
 
+router.get('/', async (req, res, next) => {
+  try {
+    if (!req.user) return res.status(200).json(null);
+    const fullUserWithoutPassword = await User.findOne({
+      where: {
+        id: req.user.id,
+      },
+      attributes: {
+        exclude: ['password'],
+      },
+      include: [
+        {
+          model: Post,
+          attributes: {
+            include: ['id'],
+          },
+        },
+        {
+          model: User,
+          as: 'Followings',
+          attributes: {
+            include: ['id'],
+          },
+        },
+        {
+          model: User,
+          as: 'Followers',
+          attributes: {
+            include: ['id'],
+          },
+        },
+      ],
+    });
+    return res.status(200).json(fullUserWithoutPassword);
+  } catch (error) {
+    console.error(error);
+    next(error);
+  }
+});
+
 router.post('/', isNotLoggedIn, async (req, res, next) => {
   try {
     const exUser = await User.findOne({
@@ -52,14 +92,23 @@ router.post('/login', isNotLoggedIn, (req, res, next) => {
         include: [
           {
             model: Post,
+            attributes: {
+              include: ['id'],
+            },
           },
           {
             model: User,
             as: 'Followings',
+            attributes: {
+              include: ['id'],
+            },
           },
           {
             model: User,
             as: 'Followers',
+            attributes: {
+              include: ['id'],
+            },
           },
         ],
       });


### PR DESCRIPTION
1. package.json
  - install morgan

2. app.js
  - morgan을 사용하여 클라이언트 요청 로그 출력
  - 모든 cors 요청 허용 -> 프론트 서버로 변경
  - cors에서 클라이언트로 부터 쿠키-세션을 받아오기 위해 credentials 옵션 추가
  - 게시글을 불러오는 posts라우터 연결

3. post.js
  - 게시글 작성 요청 라우터 구현(POST /post)
  - 게시글 작성 시 db에 저장 후 게시글을 db에서 불러와 클라이언트로 작성 정보를 보냄
  - 댓글 작성 요청 라우터 구현(POST /:postId/comment)
  - 댓글 작성 시 먼저 댓글이 작성 가능한 게시글인지 확인 후 댓글을 db에 저장
  - db에 저장 후 댓글 정보를 클라이언트에 전송

4. posts.js
  - 기존 작성 된 게시글을 불러오는 라우터 구현
  - 게시글은 limit으로 10개 씩 불러옴(추후 lastId 정보로 다음 10개 씩 불러오는 방식 구현 예정)

5. user.js
  - 유저 정보를 불러오는 라우터 구현
  - 유저 정보를 불러올 때 먼저 req.user를 확인하여 로그인 된 유저인지 확인
  - 로그인 되어있다면, 비밀번호를 제외한 정보를 전송