### PR TITLE
feat: 기존 더미데이터로 받아오던 게시글 실제 백엔드와 연결

### DIFF
--- a/front/actions/user.js
+++ b/front/actions/user.js
@@ -1,5 +1,6 @@
 import { createAsyncActions } from '../utils/factory';
 
+export const LOAD_MY_INFO = createAsyncActions('LOAD_MY_INFO');
 export const LOG_IN = createAsyncActions('LOG_IN');
 export const LOG_OUT = createAsyncActions('LOG_OUT');
 export const SIGN_UP = createAsyncActions('SIGN_UP');

--- a/front/components/PostCard.js
+++ b/front/components/PostCard.js
@@ -109,7 +109,7 @@ PostCard.propTypes = {
     id: PropTypes.string, // 더미데이터에서는 스트링으로 받고 실제로는 정수로 받음
     User: PropTypes.object,
     content: PropTypes.string,
-    createdAt: PropTypes.object,
+    createdAt: PropTypes.string,
     Comments: PropTypes.arrayOf(PropTypes.object),
     Images: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -15,7 +15,6 @@
         "antd": "^4.24.1",
         "axios": "^1.1.3",
         "babel-plugin-styled-components": "^2.0.7",
-        "dotenv": "^16.0.3",
         "immer": "^9.0.16",
         "next": "^12.3.2",
         "next-redux-wrapper": "^8.0.0",
@@ -1433,14 +1432,6 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.3.tgz",
       "integrity": "sha512-Gj9hZN3a07cbR6zviMUBOMPdWxYhbMI+x+WS0NAIu2zFZmbK8ys9R79g+iG9qLnlCwpFoaB+fKy8Pdv470GsPA=="
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5362,11 +5353,6 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.3.tgz",
       "integrity": "sha512-Gj9hZN3a07cbR6zviMUBOMPdWxYhbMI+x+WS0NAIu2zFZmbK8ys9R79g+iG9qLnlCwpFoaB+fKy8Pdv470GsPA=="
-    },
-    "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "emoji-regex": {
       "version": "9.2.2",

--- a/front/package.json
+++ b/front/package.json
@@ -15,7 +15,6 @@
     "antd": "^4.24.1",
     "axios": "^1.1.3",
     "babel-plugin-styled-components": "^2.0.7",
-    "dotenv": "^16.0.3",
     "immer": "^9.0.16",
     "next": "^12.3.2",
     "next-redux-wrapper": "^8.0.0",

--- a/front/pages/index.js
+++ b/front/pages/index.js
@@ -5,6 +5,7 @@ import AppLayout from '../components/AppLayout';
 import PostForm from '../components/PostForm';
 import PostCard from '../components/PostCard';
 import { LOAD_POSTS } from '../actions/post';
+import { LOAD_MY_INFO } from '../actions/user';
 
 const Home = () => {
   const dispatch = useDispatch();
@@ -14,6 +15,9 @@ const Home = () => {
   );
 
   useEffect(() => {
+    dispatch({
+      type: LOAD_MY_INFO.request,
+    });
     dispatch({
       type: LOAD_POSTS.request,
     });

--- a/front/reducers/post.js
+++ b/front/reducers/post.js
@@ -1,5 +1,4 @@
 import produce from 'immer';
-import { faker } from '@faker-js/faker';
 
 import {
   ADD_POST,
@@ -25,56 +24,6 @@ export const initialState = {
   addCommentDone: false,
   addCommentError: null,
 };
-
-faker.seed(1234);
-export const generateDummyPost = (number) =>
-  Array(number)
-    .fill()
-    .map(() => ({
-      id: faker.datatype.uuid(),
-      User: {
-        id: faker.datatype.uuid(),
-        nickname: faker.internet.userName(),
-      },
-      content: faker.lorem.paragraph(),
-      Images: [
-        {
-          src: faker.image.image(640, 480, true),
-        },
-      ],
-      Comments: [
-        {
-          User: {
-            id: faker.datatype.uuid(),
-            nickname: faker.internet.userName(),
-          },
-          content: faker.lorem.sentence(),
-        },
-      ],
-    }));
-
-initialState.mainPosts = initialState.mainPosts.concat(generateDummyPost(10));
-
-const dummyPost = (data) => ({
-  id: data.id,
-  content: data.content,
-  User: {
-    id: 1,
-    email: 'test@test.com',
-    nickname: 'gigo96',
-  },
-  Images: [],
-  Comments: [],
-});
-
-const dummyComment = (data) => ({
-  id: faker.data.uuid(),
-  content: data,
-  User: {
-    id: 1,
-    nickname: 'gigo96',
-  },
-});
 
 export const addPost = (data) => ({
   type: ADD_POST.request,
@@ -110,7 +59,7 @@ const reducer = (state = initialState, action) => {
         draft.addPostError = null;
         break;
       case ADD_POST.success:
-        draft.mainPosts.unshift(dummyPost(action.data));
+        draft.mainPosts.unshift(action.data);
         draft.addPostLoading = false;
         draft.addPostDone = true;
         break;
@@ -138,8 +87,9 @@ const reducer = (state = initialState, action) => {
         draft.addCommentError = null;
         break;
       case ADD_COMMENT.success: {
-        const post = draft.mainPosts.find((v) => v.id === action.data.postId);
-        post.Comments.unshift(dummyComment(action.data.content));
+        console.log('post data', action.data);
+        const post = draft.mainPosts.find((v) => v.id === action.data.PostId);
+        post.Comments.unshift(action.data);
         draft.addCommentLoading = false;
         draft.addCommentDone = true;
         break;

--- a/front/reducers/user.js
+++ b/front/reducers/user.js
@@ -7,9 +7,13 @@ import {
   FOLLOW,
   UNFOLLOW,
   CHANGE_NICKNAME,
+  LOAD_MY_INFO,
 } from '../actions/user';
 
 export const initialState = {
+  loadMyInfoLoading: false,
+  loadMyInfoDone: false,
+  loadMyInfoError: null,
   logInLoading: false,
   logInDone: false,
   logInError: null,
@@ -61,6 +65,20 @@ export const logoutRequestAction = (data) => {
 const reducer = (state = initialState, action) =>
   produce(state, (draft) => {
     switch (action.type) {
+      case LOAD_MY_INFO.request:
+        draft.loadMyInfoLoading = true;
+        draft.loadMyInfoDone = false;
+        draft.loadMyInfoError = null;
+        break;
+      case LOAD_MY_INFO.success:
+        draft.loadMyInfoLoading = false;
+        draft.loadMyInfoDone = true;
+        draft.me = action.data;
+        break;
+      case LOAD_MY_INFO.failure:
+        draft.loadMyInfoLoading = false;
+        draft.loadMyInfoError = action.error;
+        break;
       case FOLLOW.request:
         draft.followLoading = true;
         draft.followDone = false;

--- a/front/sagas/index.js
+++ b/front/sagas/index.js
@@ -1,13 +1,11 @@
 import { all, fork } from 'redux-saga/effects';
 import axios from 'axios';
-import dotenv from 'dotenv';
 
 import userSaga from './user';
 import postSaga from './post';
 
-dotenv.config();
-
-axios.defaults.baseURL = process.env.AXIOS_DEFAULTS_BASEURL;
+axios.defaults.baseURL = 'http://localhost:3065';
+axios.defaults.withCredentials = true;
 
 export default function* rootSaga() {
   yield all([fork(userSaga), fork(postSaga)]);

--- a/front/sagas/post.js
+++ b/front/sagas/post.js
@@ -1,6 +1,5 @@
 import { all, fork, takeLatest, put, delay, call } from 'redux-saga/effects';
 import axios from 'axios';
-import { faker } from '@faker-js/faker';
 
 import {
   ADD_POST,
@@ -9,28 +8,22 @@ import {
   LOAD_POSTS,
 } from '../actions/post';
 import { ADD_POST_TO_ME, REMOVE_POST_OF_ME } from '../reducers/user';
-import { generateDummyPost } from '../reducers/post';
 
 function addPostAPI(data) {
-  return axios.post('/api/post', data);
+  return axios.post('/post', { content: data });
 }
 
 function* addPost(action) {
   try {
-    yield delay(1000);
-    // const result = yield call(addPostAPI, action.data);
+    const result = yield call(addPostAPI, action.data);
 
-    const id = faker.data.uuid();
     yield put({
       type: ADD_POST.success,
-      data: {
-        id,
-        content: action.data,
-      },
+      data: result.data,
     });
     yield put({
       type: ADD_POST_TO_ME,
-      data: id,
+      data: result.data.id,
     });
   } catch (error) {
     yield put({
@@ -41,16 +34,16 @@ function* addPost(action) {
 }
 
 function loadPostAPI() {
-  return axios.get('/api/posts');
+  return axios.get('/posts');
 }
 
-function* loadPost(action) {
+function* loadPost() {
   try {
-    yield delay(1000);
-    // const result = yield call(addPostAPI);
+    const result = yield call(loadPostAPI);
+    console.log('loadPost', result.data);
     yield put({
       type: LOAD_POSTS.success,
-      data: generateDummyPost(10),
+      data: result.data,
     });
   } catch (error) {
     yield put({
@@ -86,19 +79,18 @@ function* removePost(action) {
 }
 
 function addCommentAPI(data) {
-  return axios.post(`/api/post/${data.postId}/comment`, data);
+  return axios.post(`/post/${data.postId}/comment`, data);
 }
 
 function* addComment(action) {
   try {
-    yield delay(1000);
-    // const result = yield call(addCommentAPI, action.data);
-    console.log(action.data);
+    const result = yield call(addCommentAPI, action.data);
     yield put({
       type: ADD_COMMENT.success,
-      data: action.data,
+      data: result.data,
     });
   } catch (error) {
+    console.error(error);
     yield put({
       type: ADD_COMMENT.failure,
       data: error.response.data,

--- a/front/sagas/user.js
+++ b/front/sagas/user.js
@@ -1,7 +1,33 @@
 import { all, fork, takeLatest, put, delay, call } from 'redux-saga/effects';
 import axios from 'axios';
 
-import { LOG_IN, LOG_OUT, SIGN_UP, FOLLOW, UNFOLLOW } from '../actions/user';
+import {
+  LOG_IN,
+  LOG_OUT,
+  SIGN_UP,
+  FOLLOW,
+  UNFOLLOW,
+  LOAD_MY_INFO,
+} from '../actions/user';
+
+function loadMyInfoAPI() {
+  return axios.get('/user');
+}
+
+function* loadMyInfo(action) {
+  try {
+    const result = yield call(loadMyInfoAPI);
+    yield put({
+      type: LOAD_MY_INFO.success,
+      data: result.data,
+    });
+  } catch (error) {
+    yield put({
+      type: LOAD_MY_INFO.failure,
+      error: error.response.data,
+    });
+  }
+}
 
 function logInAPI(data) {
   return axios.post('/user/login', data);
@@ -31,7 +57,7 @@ function* logOut(action) {
     const result = yield call(logOutAPI);
     yield put({
       type: LOG_OUT.success,
-      data: action.data,
+      data: result.data,
     });
   } catch (error) {
     yield put({
@@ -99,6 +125,10 @@ function* unFollow(action) {
   }
 }
 
+function* watchLoadMyInfo() {
+  yield takeLatest(LOAD_MY_INFO.request, loadMyInfo);
+}
+
 function* watchLogIn() {
   yield takeLatest(LOG_IN.request, logIn);
 }
@@ -119,6 +149,7 @@ function* watchUnfollow() {
 
 export default function* userSaga() {
   yield all([
+    fork(watchLoadMyInfo),
     fork(watchFollow),
     fork(watchUnfollow),
     fork(watchLogIn),


### PR DESCRIPTION
1.components/PostCard.js

  - 백엔드에서 보내주는 정보 중 생성 날짜 object에서 string으로 맞게 변경

1.actions/user.js

  - 사용자 정보를 받아오는 LOAD_MY_INFO action 생성

3.pages/index.js
  - 사용자 정보를 불러오는 액션 dispatch

4.reducers/user.js
  - 사용자 정보를 불러오는 변수 및 리듀서 정의

5.reducers/post.js
  - 백엔드와 연결함에 따라 기존 게시글을 더미데이터로 불러오던 것 백엔드에 연결 및 더미데이터 삭제

6.sagas/index.js
  - fix: 기존 dotenv로 백엔드 url을 환경변수로 지정하던 것 프론트에서 환경변수를 사용하는 것이 맞지 않아 변경
  - 기존 로그인 후 새로고침을 하면 로그인이 풀리는 듯한 현상 수정을 위해 credential 옵션 활성화

7.sagas/user.js
  - 사용자 정보를 불러오는 비동기 요청 구현

8.sagas/post.js
  - 게시글 데이터 비동기 요청 더미데이터 -> 백엔드 연결
  - 게시글 생성 비동기 요청 데미데이터 -> 백엔드 연결
  - 댓글 생성 비동기 요청 더미데이터 -> 백엔드 연결