### PR TITLE
feat: 이미지 업로드 구현

### DIFF
--- a/front/actions/post.js
+++ b/front/actions/post.js
@@ -6,3 +6,5 @@ export const REMOVE_POST = createAsyncActions('REMOVE_POST');
 export const LOAD_POSTS = createAsyncActions('LOAD_POST');
 export const LIKE_POST = createAsyncActions('LIKE_POST');
 export const UNLIKE_POST = createAsyncActions('UNLIKE_POST');
+export const UPLOAD_IMAGES = createAsyncActions('UPLOAD_IMAGE');
+export const REMOVE_IMAGE = 'REMOVE_IMAGE';

--- a/front/components/ImagesZoom/index.js
+++ b/front/components/ImagesZoom/index.js
@@ -11,6 +11,7 @@ import {
   ImageWrapper,
   Indicator,
 } from './styles';
+import { BACKEND } from '../../utils/factory';
 
 const ImagesZoom = ({ images, onClose }) => {
   const [CurrentSlide, setCurrentSlide] = useState(0);
@@ -33,8 +34,8 @@ const ImagesZoom = ({ images, onClose }) => {
             slidesToScroll={1}
           >
             {images.map((image) => (
-              <ImageWrapper key={image.src}>
-                <img src={image.src} alt={image.src} />
+              <ImageWrapper key={`${BACKEND}/${image.name}`}>
+                <img src={`${BACKEND}/${image.name}`} alt={image.name} />
               </ImageWrapper>
             ))}
           </Slick>

--- a/front/components/PostImages.js
+++ b/front/components/PostImages.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { PlusOutlined } from '@ant-design/icons';
 
 import ImagesZoom from './ImagesZoom';
+import { BACKEND } from '../utils/factory';
 
 const PostImages = ({ images }) => {
   const [showImagesZoom, setShowImagesZoom] = useState(false);
@@ -21,8 +22,8 @@ const PostImages = ({ images }) => {
         <img
           style={{ width: '50%', display: 'inline-block' }}
           role='presentation'
-          src={images[0].src}
-          alt={images[0].src}
+          src={`${BACKEND}/${images[0].name}`}
+          alt={`${BACKEND}/${images[0].name}`}
           onClick={onZoom}
         />
         {showImagesZoom && <ImagesZoom images={images} onClose={onClose} />}
@@ -35,15 +36,15 @@ const PostImages = ({ images }) => {
         <img
           style={{ width: '50%', display: 'inline-block' }}
           role='presentation'
-          src={images[0].src}
-          alt={images[0].src}
+          src={`${BACKEND}/${images[0].name}`}
+          alt={`${BACKEND}/${images[0].name}`}
           onClick={onZoom}
         />
         <img
           style={{ width: '50%', display: 'inline-block' }}
           role='presentation'
-          src={images[1].src}
-          alt={images[1].src}
+          src={`${BACKEND}/${images[1].name}`}
+          alt={`${BACKEND}/${images[1].name}`}
           onClick={onZoom}
         />
         {showImagesZoom && <ImagesZoom images={images} onClose={onClose} />}
@@ -56,8 +57,8 @@ const PostImages = ({ images }) => {
         <img
           style={{ width: '50%', display: 'inline-block' }}
           role='presentation'
-          src={images[0].src}
-          alt={images[0].src}
+          src={`${BACKEND}/${images[0].name}`}
+          alt={`${BACKEND}/${images[0].name}`}
           onClick={onZoom}
         />
         <div

--- a/front/reducers/post.js
+++ b/front/reducers/post.js
@@ -7,6 +7,8 @@ import {
   LOAD_POSTS,
   LIKE_POST,
   UNLIKE_POST,
+  UPLOAD_IMAGES,
+  REMOVE_IMAGE,
 } from '../actions/post';
 
 export const initialState = {
@@ -31,12 +33,10 @@ export const initialState = {
   unlikePostLoading: false,
   unlikePostDone: false,
   unlikePostError: null,
+  uploadImagesLoading: false,
+  uploadImagesDone: false,
+  uploadImagesError: null,
 };
-
-export const addPost = (data) => ({
-  type: ADD_POST.request,
-  data,
-});
 
 export const addComment = (data) => ({
   type: ADD_COMMENT.request,
@@ -136,6 +136,23 @@ const reducer = (state = initialState, action) => {
       case UNLIKE_POST.failure:
         draft.unlikePostLoading = false;
         draft.unlikePostError = action.error;
+      case UPLOAD_IMAGES.request:
+        draft.uploadImagesLoading = true;
+        draft.uploadImagesDone = false;
+        draft.uploadImagesError = null;
+        break;
+      case UPLOAD_IMAGES.success: {
+        draft.imagePaths = action.data;
+        draft.uploadImagesLoading = false;
+        draft.uploadImagesDone = true;
+        break;
+      }
+      case UPLOAD_IMAGES.failure:
+        draft.uploadImagesLoading = false;
+        draft.uploadImagesError = action.error;
+      case REMOVE_IMAGE:
+        draft.imagePaths = draft.imagePaths.filter((v, i) => i !== action.data);
+        break;
       default:
         break;
     }

--- a/front/sagas/post.js
+++ b/front/sagas/post.js
@@ -1,4 +1,4 @@
-import { all, fork, takeLatest, put, delay, call } from 'redux-saga/effects';
+import { all, fork, takeLatest, put, call } from 'redux-saga/effects';
 import axios from 'axios';
 
 import {
@@ -8,6 +8,7 @@ import {
   LOAD_POSTS,
   LIKE_POST,
   UNLIKE_POST,
+  UPLOAD_IMAGES,
 } from '../actions/post';
 import { ADD_POST_TO_ME, REMOVE_POST_OF_ME } from '../reducers/user';
 
@@ -31,7 +32,7 @@ function* loadPost() {
 }
 
 function addPostAPI(data) {
-  return axios.post('/post', { content: data });
+  return axios.post('/post', data);
 }
 
 function* addPost(action) {
@@ -139,6 +140,26 @@ function* unlikePost(action) {
   }
 }
 
+function uploadImagesAPI(images) {
+  return axios.post(`/post/images`, images);
+}
+
+function* uploadImages(action) {
+  try {
+    const result = yield call(uploadImagesAPI, action.data);
+    yield put({
+      type: UPLOAD_IMAGES.success,
+      data: result.data,
+    });
+  } catch (error) {
+    console.error(error);
+    yield put({
+      type: UPLOAD_IMAGES.failure,
+      data: error.response.data,
+    });
+  }
+}
+
 function* watchLoadPost() {
   yield takeLatest(LOAD_POSTS.request, loadPost);
 }
@@ -163,6 +184,10 @@ function* watchUnlikePost() {
   yield takeLatest(UNLIKE_POST.request, unlikePost);
 }
 
+function* watchUploadImages() {
+  yield takeLatest(UPLOAD_IMAGES.request, uploadImages);
+}
+
 export default function* postSaga() {
   yield all([
     fork(watchLoadPost),
@@ -171,5 +196,6 @@ export default function* postSaga() {
     fork(watchAddComment),
     fork(watchLikePost),
     fork(watchUnlikePost),
+    fork(watchUploadImages),
   ]);
 }

--- a/front/store/configureStore.js
+++ b/front/store/configureStore.js
@@ -19,7 +19,9 @@ const createStore = () => {
   const store = configureStore({
     reducer: rootReducer,
     middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware().concat(middlewares),
+      getDefaultMiddleware({
+        serializableCheck: false,
+      }).concat(middlewares),
     devTools: isDev,
   });
 

--- a/front/utils/factory.js
+++ b/front/utils/factory.js
@@ -4,3 +4,4 @@ export const createAsyncActions = (suffixOfActions) => ({
   failure: suffixOfActions + '_FAILURE',
   clear: suffixOfActions + '_CLEAR',
 });
+export const BACKEND = 'http://localhost:3065';


### PR DESCRIPTION
1.actions/post.js
  - 이미지를 업로드하는 액션 생성, 이미지를 제거하는 액션 생성

2.components/ImagesZoom/index.js
  - fix: 기존 src로 잘못 되어있던 이미지 변수 name으로 수정

3.utils/factory.js
  - backend url 매크로 변수 설정

4.store/configureStore.js
  - formData를 변환하지 않고 그대로 전달하기 위해 redux-toolkit의 기본 미들웨어에서 직렬화 체크 기능 제거

5.sagas/post.js
  - 이미지를 업로드 하는 비동기 saga 요청 구현

6.reducers/post.js
  - 사용하지 않는 액션 요청인 addPost 삭제
  - 이미지 업로드 reducer 구현
  - 이미지 게시글 등록 전 삭제하는 경우 삭제 reducer 구현

7.components/PostImages.js
  - 이미지 경로 백엔드 url 추가 및 src -> name으로 변경

8.components/PostForm.js
  - 게시글 작성 중 이미지 등록 / 삭제 기능 추가
  - 게시글 등록 할 때 작성된 content가 없으면 경고창 생성
  - 게시글 등록 할 때 image와 content를 formData 형식으로 보냄