### PR TITLE
feat: 리트윗, 게시글 페이지네이션 구현

### DIFF
--- a/back/router/posts.js
+++ b/back/router/posts.js
@@ -1,11 +1,16 @@
 import express from 'express';
-
+import { Op } from 'sequelize';
 import { Post, User, Comment, Image } from '../models/index.js';
 
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
   try {
+    const where = {};
+    const lastId = parseInt(req.query.lastId, 10);
+    if (lastId) {
+      where.id = { [Op.lt]: lastId };
+    }
     const posts = await Post.findAll({
       limit: 10,
       order: [
@@ -31,6 +36,19 @@ router.get('/', async (req, res, next) => {
           model: User,
           as: 'Likers',
           attributes: ['id'],
+        },
+        {
+          model: Post,
+          as: 'Retweet',
+          include: [
+            {
+              model: User,
+              attributes: ['id', 'nickname'],
+            },
+            {
+              model: Image,
+            },
+          ],
         },
       ],
     });


### PR DESCRIPTION
1.router/posts.js
  - 리트윗 기능 추가에 따라 데이터 보낼 때 리트윗 데이터를 더해서 전송
  - 프론트로부터 마지막 게시글의 아이디를 받아 게시글을 보낼 때 10개 단위로 끊어서 보냄

2.post.js
  - 리트윗 기능 구현 리트윗은 먼저 리트윗하는 포스트가 존재하는지, 이미 리트윗 했던 게시글인지, 내가 쓴 게시글을 리트윗하는 것인지 검사한다. 모든 검사를 통과하면 리트윗을 db에 저장하고, 리트윗 게시글의 정보를 프론트로 보낸다.