### PR TITLE
feat: 공유를 위해 개인 게시글 분리 라우터 구현

### DIFF
--- a/front/actions/post.js
+++ b/front/actions/post.js
@@ -4,6 +4,7 @@ export const ADD_POST = createAsyncActions('ADD_POST');
 export const ADD_COMMENT = createAsyncActions('ADD_COMMENT');
 export const REMOVE_POST = createAsyncActions('REMOVE_POST');
 export const LOAD_POSTS = createAsyncActions('LOAD_POSTS');
+export const LOAD_POST = createAsyncActions('LOAD_POST');
 export const LIKE_POST = createAsyncActions('LIKE_POST');
 export const UNLIKE_POST = createAsyncActions('UNLIKE_POST');
 export const UPLOAD_IMAGES = createAsyncActions('UPLOAD_IMAGE');

--- a/front/pages/post/[id].js
+++ b/front/pages/post/[id].js
@@ -1,0 +1,56 @@
+import { useRouter } from 'next/router';
+import axios from 'axios';
+import { END } from 'redux-saga';
+import { useSelector } from 'react-redux';
+import Head from 'next/head';
+
+import wrapper from '../../store/configureStore';
+import { LOAD_POST } from '../../actions/post';
+import { LOAD_MY_INFO } from '../../actions/user';
+import AppLayout from '../../components/AppLayout';
+import PostCard from '../../components/PostCard';
+
+const Post = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const { singlePost } = useSelector((state) => state.post);
+
+  return (
+    <AppLayout>
+      <Head>
+        <title>{singlePost.User.nickname}의 게시글</title>
+        <meta
+          property='og:title'
+          content={`${singlePost.User.nicname}님의 게시글`}
+        />
+        <meta property='og:description' content={singlePost.content} />
+        <meta property='og:image' content={singlePost.content} />
+        <meta property='og:url' content={`http://localhost:3060/post/${id}`} />
+      </Head>
+      singlePost ? <PostCard post={singlePost} />
+    </AppLayout>
+  );
+};
+
+export const getServerSideProps = wrapper.getServerSideProps(
+  (store) =>
+    async ({ req, params }) => {
+      const cookie = req?.headers.cookie;
+      axios.defaults.headers.Cookie = '';
+
+      if (req && cookie) {
+        axios.defaults.headers.Cookie = cookie;
+      }
+      store.dispatch({
+        type: LOAD_MY_INFO.request,
+      });
+      store.dispatch({
+        type: LOAD_POST.request,
+        data: params.id,
+      });
+      store.dispatch(END);
+      await store.sagaTask.toPromise();
+    }
+);
+
+export default Post;

--- a/front/reducers/post.js
+++ b/front/reducers/post.js
@@ -10,15 +10,20 @@ import {
   UPLOAD_IMAGES,
   REMOVE_IMAGE,
   RETWEET,
+  LOAD_POST,
 } from '../actions/post';
 
 export const initialState = {
   mainPosts: [],
   imagePaths: [],
+  singlePost: null,
   hasMorePosts: true,
   loadPostsLoading: false,
   loadPostsDone: false,
   loadPostsError: null,
+  loadPostLoading: false,
+  loadPostDone: false,
+  loadPostError: null,
   addPostLoading: false,
   addPostDone: false,
   addPostError: null,
@@ -64,6 +69,20 @@ const reducer = (state = initialState, action) => {
       case LOAD_POSTS.failure:
         draft.loadPostsLoading = false;
         draft.loadPostsError = action.error;
+        break;
+      case LOAD_POST.request:
+        draft.loadPostLoading = true;
+        draft.loadPostDone = false;
+        draft.loadPostError = null;
+        break;
+      case LOAD_POST.success:
+        draft.loadPostLoading = false;
+        draft.loadPostDone = true;
+        draft.singlePost = action.data;
+        break;
+      case LOAD_POST.failure:
+        draft.loadPostLoading = false;
+        draft.loadPostError = action.error;
         break;
       case ADD_POST.request:
         draft.addPostLoading = true;

--- a/front/sagas/post.js
+++ b/front/sagas/post.js
@@ -10,16 +10,17 @@ import {
   UNLIKE_POST,
   UPLOAD_IMAGES,
   RETWEET,
+  LOAD_POST,
 } from '../actions/post';
 import { ADD_POST_TO_ME, REMOVE_POST_OF_ME } from '../reducers/user';
 
-function loadPostAPI(lastId) {
+function loadPostsAPI(lastId) {
   return axios.get(`/posts?lastId=${lastId || 0}`);
 }
 
-function* loadPost(action) {
+function* loadPosts(action) {
   try {
-    const result = yield call(loadPostAPI, action.data);
+    const result = yield call(loadPostsAPI, action.data);
     console.log(result);
     yield put({
       type: LOAD_POSTS.success,
@@ -28,6 +29,25 @@ function* loadPost(action) {
   } catch (error) {
     yield put({
       type: LOAD_POSTS.failure,
+      error: error.response.data,
+    });
+  }
+}
+
+function loadPostAPI(postId) {
+  return axios.get(`/post/${postId}`);
+}
+
+function* loadPost(action) {
+  try {
+    const result = yield call(loadPostAPI, action.data);
+    yield put({
+      type: LOAD_POST.success,
+      data: result.data,
+    });
+  } catch (error) {
+    yield put({
+      type: LOAD_POST.failure,
       error: error.response.data,
     });
   }
@@ -182,8 +202,12 @@ function* retweet(action) {
   }
 }
 
+function* watchLoadPosts() {
+  yield takeLatest(LOAD_POSTS.request, loadPosts);
+}
+
 function* watchLoadPost() {
-  yield takeLatest(LOAD_POSTS.request, loadPost);
+  yield takeLatest(LOAD_POST.request, loadPost);
 }
 
 function* watchAddPost() {
@@ -216,6 +240,7 @@ function* watchRetweet() {
 
 export default function* postSaga() {
   yield all([
+    fork(watchLoadPosts),
     fork(watchLoadPost),
     fork(watchAddPost),
     fork(watchRemovePost),


### PR DESCRIPTION
하나의 게시글을 화면에 보여주기 위해 id를 파라미터로 사용하는 동적 라우터 구현
id를 받아 해당 게시글을 따로 보여줌
이 때 ssr을 위해 getServerSideProps 사용
저장소에 siglePost 추가
state 및 비동기 요청을 위해 reducer와 saga [ get /post/postId ] 추가